### PR TITLE
Refactored shipping calculator to ton-kilometer model

### DIFF
--- a/Shipping_Cost_Calculator.py
+++ b/Shipping_Cost_Calculator.py
@@ -1,12 +1,71 @@
-# Shipping Cost Calculator
+# Shipping Cost Calculator — Ton-Kilometer Model
 
-## Input package weight and shipping rate
-weight = float(input("Enter the package weight in kilograms: "))
-rate = float(input("Enter the shipping rate per kilogram: "))
+import math
 
-## Calculate shipping cost
-shipping_cost = weight * rate
+# Global Constants
+DIM_DIVISOR = 6000          # cm³ per kg
+STEP_KG = 0.5               # round billable weight up to nearest 0.5
+BASE_FEE = 5.00             # flat base fee
+RATE_PER_KG_PER_KM = 0.002  # main rate
+MIN_CHARGE = 8.00           # minimum charge before fuel
+FUEL_PERCENTAGE = 0.15      # 15% fuel surcharge
 
-## Display the result
-print(f"Shipping Cost: {shipping_cost} USD")
+# Input and Validation
+while True:
+    try:
+        weight = float(input("Enter weight (g): "))
+        if weight <= 0:
+            print("Weight must be positive.")
+            continue
 
+        length = float(input("Enter length (cm): "))
+        if length <= 0:
+            print("Length must be positive.")
+            continue
+
+        width = float(input("Enter width (cm): "))
+        if width <= 0:
+            print("Width must be positive.")
+            continue
+
+        height = float(input("Enter height (cm): "))
+        if height <= 0:
+            print("Height must be positive.")
+            continue
+
+        distance = float(input("Enter distance (km): "))
+        if distance <= 0:
+            print("Distance must be positive.")
+            continue
+
+    except ValueError:
+        print("Invalid input. Please enter numeric values.")
+        continue
+    break
+
+# Normalize weight
+weight_kg = weight / 1000
+
+# Dimensional Weight
+dimensional_weight = (length * width * height) / DIM_DIVISOR
+
+# Billable Weight
+billable_weight = max(weight_kg, dimensional_weight)
+billable_kg = math.ceil(billable_weight / STEP_KG) * STEP_KG
+
+# Transportation Cost
+transport_pre_min = BASE_FEE + (billable_kg * distance * RATE_PER_KG_PER_KM)
+transport = max(transport_pre_min, MIN_CHARGE)
+
+# Fuel Surcharge
+fuel_surcharge = transport * FUEL_PERCENTAGE
+
+# Total
+total = round(transport + fuel_surcharge, 2)
+
+# Output
+print("\n--- Shipping Cost Breakdown ---")
+print(f"Billable Weight (kg): {billable_kg:.2f}")
+print(f"Transportation (after min ${MIN_CHARGE:.2f}): ${transport:.2f}")
+print(f"Fuel Surcharge ({FUEL_PERCENTAGE*100:.0f}%): ${fuel_surcharge:.2f}")
+print(f"Total Shipping Cost: ${total:.2f}")


### PR DESCRIPTION
This update expands the previously basic calculator (which only supported weight in kg × rate per kg) into a more realistic shipping cost estimator.

Changes made:
1.  Added dimensional weight calculation using a divisor of 6000 cm³/kg
2. Implemented billable weight = max(actual, dimensional), rounded up to nearest 0.5 kg
3. Introduced ton-kilometer pricing model:
- transport = base_fee + (billable_kg × distance_km × rate_per_kg_per_km)
- with a minimum charge safeguard = $8
4. Added fuel surcharge (15%) applied to transportation cost
5. Simplified input prompts (user enters grams + cm + km, not raw kg rate)
6. Improved output with breakdown of weights, transport, fuel, and total

### Tested Examples

| Input                          | Billable Weight | Distance | Transport (before fuel) | Total (with 15% fuel) |
|--------------------------------|-----------------|----------|--------------------------|------------------------|
| 500 g, 2×2×2 cm, 3000 km       | 0.5 kg (min)    | 3000 km  | $8.00                   | **$9.20**             |
| 500 g, 20×15×2 cm, 300 km      | 0.5 kg          | 300 km   | $8.00                   | **$9.20**             |
| 2 kg, 30×20×10 cm, 1000 km     | 2.0 kg          | 1000 km  | $9.00                   | **$10.35**            |
| 5 kg, 40×30×20 cm, 1000 km     | 5.0 kg          | 1000 km  | $15.00                  | **$17.25**            |

     